### PR TITLE
Make users able to define the pages to enable this functionality from wp-config.php

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,14 @@ To install:
 1. Click **Install Now**
 1. Click **Activate**
 
+## Instructions 
+
+By default, once you activate this plugin, it will automatically check the Gifting checkbox on **all pages**. If you want to check it only on some **spefific pages**, you'll need to add this constant on wp-config.php file:
+
+`define( 'WCSG_PAGES_TO_CHECK', array( 1, 2, 3 ) );`
+
+Each of these numbers (1,2,3) is the ID of a page where this checkbox will be checked.
+
 ## Reporting Issues
 
 If you find a problem or would like to request this plugin be extended, please [open a new Issue](https://github.com/jrick1229/wcsg-auto-check/issues/new).

--- a/wcsg-auto-check.php
+++ b/wcsg-auto-check.php
@@ -32,8 +32,10 @@
  */
 
 function wcsg_auto_check() {
-    $page_id = get_the_ID();
-    if ( $page_id == 14 ) {
+    $current_page = get_the_ID();
+    $pages_to_check = ( defined( 'WCSG_PAGES_TO_CHECK' ) ? WCSG_PAGES_TO_CHECK : true );
+
+    if ( $pages_to_check === true || in_array( $current_page, $pages_to_check ) ) {
         wp_enqueue_script( 'wcsg-auto-check-script', plugin_dir_url( __FILE__ ) . 'wcsg-auto-check.js', array( 'jquery' ), '1.0.0', true  );
     }
 }


### PR DESCRIPTION
I've updated the code to make developers able to define the pages where this functionality should be used from wp-config.php. This way, they don't need to update the plugin code directly. 

How it works now:

- If you want to check this checkbox on **all pages**, you don't need to do anything. This is the default functionality.

- If you want to check the checkbox only in **some specific pages**, you'll need to add this new constant on wp-config.php file:

`define( 'WCSG_PAGES_TO_CHECK', array( 1, 2, 3 ) );`

Each of these numbers (1,2,3) is the ID of a page where this checkbox should be checked. 


* This is just a suggestion to prevent developers to modify the plugin code. In next versions, I'd create a settings page in the backend to let the customers specify the pages (or maybe a checkbox in each page to allow them to enable this functionality). 